### PR TITLE
Use only latest data when reading value. Prevent sync errors.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,9 +32,6 @@ This is easily achieved by downloading
 
 Installing from PyPI
 =====================
-.. note:: This library is not available on PyPI yet. Install documentation is included
-   as a standard element. Stay tuned for PyPI availability!
-
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
 PyPI <https://pypi.org/project/adafruit-circuitpython-ble-berrymed_pulse_oximeter/>`_. To install for current user:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,6 +29,9 @@ intersphinx_mapping = {
     "CircuitPython": ("https://circuitpython.readthedocs.io/en/latest/", None),
 }
 
+# Show the docstring from both the class and its __init__() method.
+autoclass_content = "both"
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 


### PR DESCRIPTION
Data from the pulse oximeter arrives very quickly, but if it's polled infrequently, it will be out of date, and overwritten data can cause incorrect values, especially on BM1000B (newer model).

Issues found by adafruitguy in the Adafruit Forums: https://forums.adafruit.com/viewtopic.php?f=19&t=166909. Thank you!