### PR TITLE
Import circuitpython_typing in the try

### DIFF
--- a/adafruit_ble_berrymed_pulse_oximeter/adafruit_ble_transparent_uart.py
+++ b/adafruit_ble_berrymed_pulse_oximeter/adafruit_ble_transparent_uart.py
@@ -17,9 +17,9 @@ from adafruit_ble.characteristics.stream import StreamOut, StreamIn
 
 try:
     from typing import Optional
+    from circuitpython_typing import ReadableBuffer, WriteableBuffer
 except ImportError:
     pass
-from circuitpython_typing import ReadableBuffer, WriteableBuffer
 
 __version__ = "0.0.0+auto.0"
 __repo__ = (


### PR DESCRIPTION
Fixing:
```
Traceback (most recent call last):
  File "code.py", line 20, in <module>
  File "/lib/adafruit_ble_berrymed_pulse_oximeter/__init__.py", line 44, in <module>
  File "/lib/adafruit_ble_berrymed_pulse_oximeter/adafruit_ble_transparent_uart.py", line 22, in <module>
ImportError: no module named 'circuitpython_typing'
```